### PR TITLE
Replace Toast with Tooltip

### DIFF
--- a/index.html
+++ b/index.html
@@ -145,16 +145,9 @@ revision : 1 October 2025
                             plugins found
                         </label>
                         <button id="permalink-button" type="button" class="btn btn-sm btn-outline-light align-baseline"
-                            style="border:none">
-                            <i class="bi bi-link-45deg"></i> Copy Permalink
+                            style="border:none" data-bs-toggle="tooltip" data-bs-placement="bottom" data-bs-title="Copy Permalink">
+                            <i id="permalink-icon" class="bi bi-link-45deg"></i>
                         </button>
-                        <div class="position-fixed bottom-0 left-0 p-3 align-baseline"
-                            style="z-index: 5; left: 0; bottom: 0;color: black;">
-                            <div id="copiedToast" class="toast hide" role="alert" aria-live="assertive"
-                                aria-atomic="true" data-bs-delay="2000">
-                                <div class="toast-body"></div>
-                            </div>
-                        </div>
                     </div>
                     <div class="col-auto">
                         <label class="form-label w-auto align-baseline" for="order" style="margin: 0">Order by</label>

--- a/js/pdnpi-v3.js
+++ b/js/pdnpi-v3.js
@@ -407,16 +407,27 @@ ${data.desc.substring(0, 450)}
             });
 
             document.querySelector('#permalink-button').addEventListener('click', async () => {
+                const permalinkTooltip = bootstrap.Tooltip.getInstance('#permalink-button');
+                const permalinkIcon = document.querySelector('#permalink-icon');
+
                 try {
                     await navigator.clipboard.writeText(internal.buildPermalink());
-                    document.querySelector('#copiedToast .toast-body').textContent = 'Permalink copied to the clipboard.';
+                    permalinkTooltip.setContent({ '.tooltip-inner': 'Copied!' });
+                    permalinkIcon.classList.remove('bi-link-45deg', 'bi-check-lg', 'bi-x-circle');
+                    permalinkIcon.classList.add('bi-check-lg');
                 } catch (err) {
                     console.error('Failed to copy:', err);
-                    document.querySelector('#copiedToast .toast-body').textContent = 'Error copying Permalink to the clipboard.';
+                    permalinkTooltip.setContent({ '.tooltip-inner': 'Failed to copy' });
+                    permalinkIcon.classList.remove('bi-link-45deg', 'bi-check-lg', 'bi-x-circle');
+                    permalinkIcon.classList.add('bi-x-circle');
                 }
 
-                const toastNode = document.querySelector('#copiedToast');
-                bootstrap.Toast.getOrCreateInstance(toastNode).show();
+                // reset icon and tooltip after 2 seconds
+                setTimeout(() => {
+                    permalinkTooltip.setContent({ '.tooltip-inner': 'Copy Permalink' });
+                    permalinkIcon.classList.remove('bi-link-45deg', 'bi-check-lg', 'bi-x-circle');
+                    permalinkIcon.classList.add('bi-link-45deg');
+                }, 2000);
             });
 
             document.querySelector('#resetFilters').addEventListener('click', function() {


### PR DESCRIPTION
This removes the Toast Notification for the Permalink button, and replaces it will a changing Tooltop/Icon:

<img width="315" height="111" alt="image" src="https://github.com/user-attachments/assets/a546b009-aa1a-485c-b41f-f08cae7c57d0" />

After it has been clicked:

<img width="285" height="109" alt="image" src="https://github.com/user-attachments/assets/9c9129af-b688-4617-8a35-3fa42051473f" />


After 2 seconds, it will revert back to the original Tooltip and Icon.

I was never satisfied with appearance and position of the Toast.
Using the Tooltip and Icon follows the convention used by a lot of other websites.