### PR TITLE
Date improvements

### DIFF
--- a/js/pdnpi-v3.js
+++ b/js/pdnpi-v3.js
@@ -13,10 +13,12 @@ const pdnpi = (function () {
     class Plugin {
         constructor(data) {
             this.#data = data;
+            this.#releaseAsDate = new Date(this.#data.release);
             this.#html = this.#dataToHtml();
         }
 
         #data;
+        #releaseAsDate;
         #html;
 
         // a few of these have 0 references, but do get called through bracket notation. i.e. plugin['fieldName']
@@ -27,7 +29,7 @@ const pdnpi = (function () {
         get isActive() { return ["New", "Active", "Bundled"].some(x => equalsIgnoreCase(this.#data.status, x)); }
         get isNew() { return equalsIgnoreCase(this.#data.status, "New"); }
         get menu() { return this.#data.menu; }
-        get release() { return new Date(this.#data.release); }
+        get release() { return this.#releaseAsDate; }
         get status() { return this.#data.status; }
         get title() { return this.#data.title; }
         get type() { return this.#data.type; }
@@ -166,8 +168,7 @@ const pdnpi = (function () {
             }
 
             const dot = `<i class="bi bi-dot"></i>`;
-            const release = new Date(data.release);
-            const since = Plugin.#timeSince(new Date(release));
+            const since = Plugin.#timeSince(this.#releaseAsDate);
             const dlls = (data.dlls || "").split(",");
             const hoverdlls = (data.dlls || "").replace(/, /g, "\n").trim() || "N/A"; // replace comma-space with newline for dll tooltip
             let dllText = `<sp class='dll-1'>${dlls[0] || 'N/A'}</sp>`;


### PR DESCRIPTION
Two improvements here:

* created a comparer function for use in a `.sort()`. and we just swap the parameters to sort in the other direction.
* In `timeSince()`, use the [`Temporal` API](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal) if the browser has support. This gives us more accurate results, with less custom code.


Firefox (which supports `Temporal`):
`15 years 11 months` Correct!
<img width="287" height="123" alt="image" src="https://github.com/user-attachments/assets/542c3d14-b7a3-4385-8635-c07897fcc95c" />

Browsers without support use the existing code:
`15 years 12 months` 12 months!? Wouldn't that just be 16 years? But of course 16 years is not correct either.
<img width="276" height="114" alt="{512BD676-B5CC-403E-9B68-0CE9D189473F}" src="https://github.com/user-attachments/assets/cf933630-3a27-4c4f-9580-ea7f61153fa2" />
