### PR TITLE
Fix alt plugin display

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -20,12 +20,8 @@ import {Plugin} from "plugin";
         const response = await fetch("index/plugin-index.json");
         const json = Object.assign({plugin_index: []}, await response.json());
 
-        json.plugin_index.forEach(item => {
-            const plugin = new Plugin(item);
-
-            index.plugins.push(plugin);
-            index.pluginMap[plugin.topicId] = plugin;
-        });
+        json.plugin_index.forEach(item => index.plugins.push(new Plugin(item)));
+        index.pluginMap = Object.groupBy(index.plugins, plugin => plugin.topicId);
 
         console.log(`Loaded ${index.plugins.length} plugins from index/plugin-index.json`, index);
 

--- a/js/plugin.js
+++ b/js/plugin.js
@@ -278,12 +278,24 @@ export class Plugin {
         return "just now";
     }
 
+    #findAltPlugin() {
+        const plugins = index.pluginMap[this.#data.alt_topic];
+        if (!plugins) return;
+
+        const filtered = plugins.filter(p => p.title !== this.title);
+        if (filtered.length === 0) return;
+        if (filtered.length === 1) return filtered[0];
+
+        const pack = filtered.find(p => util.equalsIgnoreCase(p.type, "Plugin Pack"));
+        return pack || filtered[0];
+    }
+
     #dataToHtml() {
         const data = this.#data;
 
         let altLink = '';
         if (data.hasOwnProperty('alt_topic') && data.alt_topic !== '') {
-            const altPlugin = index.plugins.find(p => p.topicId === data.alt_topic);
+            const altPlugin = this.#findAltPlugin();
             const altTitle = altPlugin ? altPlugin.title : 'unknown';
             const altDisplay = altPlugin ? altPlugin.title : "#" + data.alt_topic;
             altLink = `<sp class='alt'>See also: <a target="_blank" href="https://forums.getpaint.net/topic/${data.alt_topic}-${util.slugify(altTitle)}">


### PR DESCRIPTION
I didn't realize a topic id could be linked to multiple entries, try to find the best entry in the list for display.

If there are multiple entries associated with a topic id, favor the plugin pack entry if one is in the list. Otherwise, use the first entry in the list that isn't itself.